### PR TITLE
updated calendar popover display for ILM

### DIFF
--- a/addon/components/ilios-calendar-event-month.js
+++ b/addon/components/ilios-calendar-event-month.js
@@ -3,7 +3,7 @@ import { default as CalendarEvent } from 'el-calendar/components/calendar-event'
 import layout from '../templates/components/ilios-calendar-event-month';
 import moment from 'moment';
 
-const {computed, Handlebars} = Ember;
+const {computed, Handlebars, isBlank} = Ember;
 const {SafeString} = Handlebars;
 
 export default CalendarEvent.extend({
@@ -11,13 +11,25 @@ export default CalendarEvent.extend({
   event: null,
   timeFormat: 'h:mma',
   classNameBindings: [':event', ':event-pos', ':ilios-calendar-event', 'event.eventClass', ':month-event'],
-  tooltipContent: computed('event', function(){
-    let str = this.get('event.location') + '<br />' +
-      moment(this.get('event.startDate')).format(this.get('timeFormat')) + ' - ' +
-      moment(this.get('event.endDate')).format(this.get('timeFormat')) + '<br />' +
-      this.get('event.name');
-  
-    return str;
+  tooltipContent: computed('event', function() {
+    const location = this.get('event.location');
+    const name = this.get('event.name');
+    const startTime = moment(this.get('event.startDate')).format(this.get('timeFormat'));
+    const endTime = moment(this.get('event.endDate')).format(this.get('timeFormat'));
+    const dueThisDay = this.get('dueThisDay');
+    const isILM = this.get('event.ilmSession');
+
+    if (isILM) {
+      if (location) {
+        return `${location}<br />${dueThisDay}<br />${name}`;
+      } else {
+        return `${dueThisDay}<br />${name}`;
+      }
+    } else if (isBlank(location)) {
+      return `TBD<br />${startTime} - ${endTime}<br />${name}`;
+    } else {
+      return `${location}<br />${startTime} - ${endTime}<br />${name}`;
+    }
   }),
   style: computed(function() {
     return new SafeString('');

--- a/addon/components/ilios-calendar-event.js
+++ b/addon/components/ilios-calendar-event.js
@@ -3,7 +3,7 @@ import { default as CalendarEvent } from 'el-calendar/components/calendar-event'
 import layout from '../templates/components/ilios-calendar-event';
 import moment from 'moment';
 
-const {computed, Handlebars} = Ember;
+const {computed, Handlebars, isBlank} = Ember;
 const {SafeString} = Handlebars;
 
 export default CalendarEvent.extend({
@@ -11,23 +11,36 @@ export default CalendarEvent.extend({
   event: null,
   timeFormat: 'h:mma',
   classNameBindings: [':event', ':event-pos', ':ilios-calendar-event', 'event.eventClass', ':day'],
-  tooltipContent: computed('event', function(){
+  tooltipContent: computed('event', function() {
     if (this.get('event') == null) {
       return '';
     }
-    let str = this.get('event.location') + '<br />' +
-      moment(this.get('event.startDate')).format(this.get('timeFormat')) + ' - ' +
-      moment(this.get('event.endDate')).format(this.get('timeFormat')) + '<br />' +
-      this.get('event.name');
-  
-    return str;
+
+    const location = this.get('event.location');
+    const name = this.get('event.name');
+    const startTime = moment(this.get('event.startDate')).format(this.get('timeFormat'));
+    const endTime = moment(this.get('event.endDate')).format(this.get('timeFormat'));
+    const dueThisDay = this.get('dueThisDay');
+    const isILM = this.get('event.ilmSession');
+
+    if (isILM) {
+      if (location) {
+        return `${location}<br />${dueThisDay}<br />${name}`;
+      } else {
+        return `${dueThisDay}<br />${name}`;
+      }
+    } else if (isBlank(location)) {
+      return `TBD<br />${startTime} - ${endTime}<br />${name}`;
+    } else {
+      return `${location}<br />${startTime} - ${endTime}<br />${name}`;
+    }
   }),
-  
+
   style: computed(function() {
     if (this.get('event') == null) {
       return new SafeString('');
     }
-    
+
     let escape = Handlebars.Utils.escapeExpression;
 
     return new SafeString(
@@ -37,7 +50,7 @@ export default CalendarEvent.extend({
        width: ${escape(this.calculateWidth())}%;`
     );
   }),
-  
+
   click(){
     this.sendAction('action', this.get('event'));
   }

--- a/addon/templates/components/ilios-calendar-day.hbs
+++ b/addon/templates/components/ilios-calendar-day.hbs
@@ -17,7 +17,7 @@
       <li class="event-column">
         {{#each hours as |hour|}}
           {{#each hour.events as |event|}}
-            {{ilios-calendar-event event=event action='selectEvent'}}
+            {{ilios-calendar-event event=event action='selectEvent' dueThisDay=dueThisDay}}
           {{/each}}
         {{/each}}
       </li>

--- a/addon/templates/components/ilios-calendar-month.hbs
+++ b/addon/templates/components/ilios-calendar-month.hbs
@@ -22,7 +22,7 @@
           </span>
           <div class="events">
             {{#each day.events as |event|}}
-              {{ilios-calendar-event-month event=event action='selectEvent'}}
+              {{ilios-calendar-event-month event=event action='selectEvent' dueThisDay=dueThisDay}}
             {{/each}}
           </div>
         </div>

--- a/addon/templates/components/ilios-calendar-week.hbs
+++ b/addon/templates/components/ilios-calendar-week.hbs
@@ -25,7 +25,7 @@
     <ul class="week-day">
       <li class="event-column">
         {{#each day.events as |event|}}
-          {{ilios-calendar-event event=event action='selectEvent'}}
+          {{ilios-calendar-event event=event action='selectEvent' dueThisDay=dueThisDay}}
         {{/each}}
       </li>
       {{#each day.hours as |hour|}}

--- a/addon/templates/components/ilios-calendar.hbs
+++ b/addon/templates/components/ilios-calendar.hbs
@@ -11,11 +11,12 @@
 </ul>
 <div class='ilios-calendar-calendar'>
   <h1 class="{{if calendarEventsPromise.isFulfilled 'loaded'}}">{{fa-icon 'spinner' spin=true}} {{loadingMessage}}</h1>
-  {{component (concat "ilios-calendar-" selectedView) 
+  {{component (concat "ilios-calendar-" selectedView)
     calendarEvents=calendarEventsPromise.content
     date=selectedDate
     selectEvent='selectEvent'
     changeDate='changeDate'
     changeView='changeView'
+    dueThisDay=dueThisDay
   }}
 </div>


### PR DESCRIPTION
Solves popover display issue for ILMs.

@jrjohnson @saschaben Please review.

Issue: [#883](https://github.com/ilios/frontend/issues/883)

##### Used to show for ILM:
<img width="230" alt="screen shot 2015-10-22 at 1 51 56 pm" src="https://cloud.githubusercontent.com/assets/7553764/10677933/1bddd422-78c4-11e5-902b-24d7ecb042b5.png">

##### Now for ILM & no-location:
<img width="236" alt="screen shot 2015-10-22 at 1 35 05 pm" src="https://cloud.githubusercontent.com/assets/7553764/10677974/4a2eba6c-78c4-11e5-97b8-173f727cdedf.png">

##### Now for no-location (non-ILM):
<img width="227" alt="screen shot 2015-10-22 at 1 35 12 pm" src="https://cloud.githubusercontent.com/assets/7553764/10677990/61b73312-78c4-11e5-9757-81b42bc0ef73.png">

##### Regular session stays the same:
<img width="234" alt="screen shot 2015-10-22 at 1 35 24 pm" src="https://cloud.githubusercontent.com/assets/7553764/10678008/74e283a6-78c4-11e5-8f8d-ec1bd59ca7a9.png">
