### PR TITLE
Display Fixes

### DIFF
--- a/addon/components/ilios-calendar-day.js
+++ b/addon/components/ilios-calendar-day.js
@@ -4,7 +4,7 @@ import layout from '../templates/components/ilios-calendar-day';
 const {run} = Ember;
 
 export default Ember.Component.extend({
-  classNames: ['ilios-calendar-month'],
+  classNames: ['ilios-calendar-day'],
   layout: layout,
   date: null,
   calendarEvents: [],

--- a/addon/components/ilios-calendar-event.js
+++ b/addon/components/ilios-calendar-event.js
@@ -3,8 +3,9 @@ import { default as CalendarEvent } from 'el-calendar/components/calendar-event'
 import layout from '../templates/components/ilios-calendar-event';
 import moment from 'moment';
 
-const {computed, Handlebars, isBlank} = Ember;
-const {SafeString} = Handlebars;
+const { computed, Handlebars, isBlank } = Ember;
+const { SafeString } = Handlebars;
+const { notEmpty }= computed;
 
 export default CalendarEvent.extend({
   layout,
@@ -35,7 +36,7 @@ export default CalendarEvent.extend({
       return `${location}<br />${startTime} - ${endTime}<br />${name}`;
     }
   }),
-
+  isIlm: notEmpty('event.ilmSession'),
   style: computed(function() {
     if (this.get('event') == null) {
       return new SafeString('');

--- a/addon/templates/components/ilios-calendar-event.hbs
+++ b/addon/templates/components/ilios-calendar-event.hbs
@@ -1,14 +1,23 @@
 {{#if event}}
   <span class='ilios-calendar-event-time'>
-    <span class='ilios-calendar-event-start'>
-      {{moment-format event.startDate 'h:mma'}}
-    </span>
-    <span class='ilios-calendar-event-end'>
-      - {{moment-format event.endDate 'h:mma'}}
-    </span>
+    {{#if isIlm}}
+      <span class='ilios-calendar-event-start'>
+        Due: {{moment-format event.startDate 'h:mma'}}
+      </span>
+    {{else}}
+      <span class='ilios-calendar-event-start'>
+        {{moment-format event.startDate 'h:mma'}}
+      </span>
+      <span class='ilios-calendar-event-end'>
+        - {{moment-format event.endDate 'h:mma'}}
+      </span>
+    {{/if}}
+    
   </span>
   <span class='ilios-calendar-event-location'>
-    {{event.location}}:
+    {{#if event.location.length}}
+      {{event.location}}:
+    {{/if}}
   </span>
   <span class='ilios-calendar-event-name'>
     {{event.name}}


### PR DESCRIPTION
Fix class for ilios-calendar-day which allows the day view to scroll.

I’m proved ILMs so they show up with a Due: and the dueByDate instead of start and end times
which don’t matter.  I cheated and didn’t translate “Due” we can deal
with that later.