### PR TITLE
prevented more html escapes

### DIFF
--- a/addon/templates/components/ilios-calendar-single-event-objective-list.hbs
+++ b/addon/templates/components/ilios-calendar-single-event-objective-list.hbs
@@ -3,7 +3,7 @@
     <li>{{domain.title}}
       <ul>
         {{#each domain.objectives as |title|}}
-          <li>{{title}}</li>
+          <li>{{{title}}}</li>
         {{/each}}
       </ul>
     </li>

--- a/addon/templates/components/ilios-calendar-single-event.hbs
+++ b/addon/templates/components/ilios-calendar-single-event.hbs
@@ -3,7 +3,7 @@
   <div class='ilios-calendar-single-event-offered-at'>{{offeredAtPhrase}}</div>
   <div class='ilios-calendar-single-event-instructors'>{{taughtByPhrase}} {{listOfInstructors}}</div>
   <div class='ilios-calendar-single-event-session-is'>{{sessionIsPhrase}}</div>
-  {{#if description}}<p>{{description}}</p><br />{{/if}}
+  {{#if description}}{{{description}}}<br />{{/if}}
 </div>
 
 <fieldset>


### PR DESCRIPTION
Fixes https://github.com/ilios/frontend/issues/1077

- [x] `http://localhost:4200/events/S0120151113O62551`: look at learning materials
- [ ] `http://localhost:4200/events/S0120151115O58353`: course objectives (MS Escape)
- [x] `http://localhost:4200/events/S0120151111O64499`: session description block