### PR TITLE
Prevent users from clicking on scheduled events

### DIFF
--- a/addon/components/ilios-calendar-event-month.js
+++ b/addon/components/ilios-calendar-event-month.js
@@ -3,14 +3,15 @@ import { default as CalendarEvent } from 'el-calendar/components/calendar-event'
 import layout from '../templates/components/ilios-calendar-event-month';
 import moment from 'moment';
 
-const {computed, Handlebars, isBlank} = Ember;
-const {SafeString} = Handlebars;
+const { computed, Handlebars, isBlank } = Ember;
+const { SafeString } = Handlebars;
+const { notEmpty, any } = computed;
 
 export default CalendarEvent.extend({
   layout,
   event: null,
   timeFormat: 'h:mma',
-  classNameBindings: [':event', ':event-pos', ':ilios-calendar-event', 'event.eventClass', ':month-event'],
+  classNameBindings: [':event', ':event-pos', ':ilios-calendar-event', 'event.eventClass', ':month-event', 'clickable:clickable'],
   tooltipContent: computed('event', function() {
     const location = this.get('event.location');
     const name = this.get('event.name');
@@ -34,7 +35,12 @@ export default CalendarEvent.extend({
   style: computed(function() {
     return new SafeString('');
   }),
+  isIlm: notEmpty('event.ilmSession'),
+  isOffering: notEmpty('event.offering'),
+  clickable: any('isIlm', 'isOffering'),
   click(){
-    this.sendAction('action', this.get('event'));
+    if(this.get('clickable')){
+      this.sendAction('action', this.get('event'));
+    }
   }
 });

--- a/addon/components/ilios-calendar-event.js
+++ b/addon/components/ilios-calendar-event.js
@@ -5,13 +5,13 @@ import moment from 'moment';
 
 const { computed, Handlebars, isBlank } = Ember;
 const { SafeString } = Handlebars;
-const { notEmpty }= computed;
+const { notEmpty, any }= computed;
 
 export default CalendarEvent.extend({
   layout,
   event: null,
   timeFormat: 'h:mma',
-  classNameBindings: [':event', ':event-pos', ':ilios-calendar-event', 'event.eventClass', ':day'],
+  classNameBindings: [':event', ':event-pos', ':ilios-calendar-event', 'event.eventClass', ':day', 'clickable:clickable'],
   tooltipContent: computed('event', function() {
     if (this.get('event') == null) {
       return '';
@@ -37,6 +37,9 @@ export default CalendarEvent.extend({
     }
   }),
   isIlm: notEmpty('event.ilmSession'),
+  isOffering: notEmpty('event.offering'),
+  clickable: any('isIlm', 'isOffering'),
+  
   style: computed(function() {
     if (this.get('event') == null) {
       return new SafeString('');
@@ -53,6 +56,8 @@ export default CalendarEvent.extend({
   }),
 
   click(){
-    this.sendAction('action', this.get('event'));
+    if(this.get('clickable')){
+      this.sendAction('action', this.get('event'));
+    }
   }
 });


### PR DESCRIPTION
When students view scheduled events they don’t have permissions to see any details.  In order to prevent confusion this stops them from clicking on these events and navigating to a single event page that is broken.