### PR TITLE
Put session details before course details

### DIFF
--- a/addon/templates/components/ilios-calendar-single-event.hbs
+++ b/addon/templates/components/ilios-calendar-single-event.hbs
@@ -8,20 +8,6 @@
 
 <fieldset>
   <div class='ilios-calendar-single-event-learningmaterial-list'>
-    <h2>{{courseLearningMaterialsPhrase}}</h2>
-    {{ilios-calendar-single-event-learningmaterial-list
-      learningMaterials=courseLearningMaterials
-      requiredPhrase=requiredPhrase
-    }}
-  </div>
-  <div class='ilios-calendar-single-event-objective-list'>
-    <h2>{{courseObjectivesPhrase}}</h2>
-    {{ilios-calendar-single-event-objective-list objectives=courseObjectives}}
-  </div>
-</fieldset>
-
-<fieldset>
-  <div class='ilios-calendar-single-event-learningmaterial-list'>
     <h2>{{sessionLearningMaterialsPhrase}}</h2>
     {{ilios-calendar-single-event-learningmaterial-list
       learningMaterials=sessionLearningMaterials
@@ -31,5 +17,19 @@
   <div class='ilios-calendar-single-event-objective-list'>
     <h2>{{sessionObjectivesPhrase}}</h2>
     {{ilios-calendar-single-event-objective-list objectives=sessionObjectives}}
+  </div>
+</fieldset>
+
+<fieldset>
+  <div class='ilios-calendar-single-event-learningmaterial-list'>
+    <h2>{{courseLearningMaterialsPhrase}}</h2>
+    {{ilios-calendar-single-event-learningmaterial-list
+      learningMaterials=courseLearningMaterials
+      requiredPhrase=requiredPhrase
+    }}
+  </div>
+  <div class='ilios-calendar-single-event-objective-list'>
+    <h2>{{courseObjectivesPhrase}}</h2>
+    {{ilios-calendar-single-event-objective-list objectives=courseObjectives}}
   </div>
 </fieldset>


### PR DESCRIPTION
This ensures that when they do stack that the session details are on
top.

Refs ilios/frontend#1295