### PR TITLE
Remove single event link from scheduled multi-day events

### DIFF
--- a/addon/components/ilios-calendar-multiday-event.js
+++ b/addon/components/ilios-calendar-multiday-event.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+import layout from '../templates/components/ilios-calendar-multiday-event';
+
+const { notEmpty, any } = Ember.computed;
+
+export default Ember.Component.extend({
+  layout: layout,
+  tagName: ['li'],
+  event: null,
+  isIlm: notEmpty('event.ilmSession'),
+  isOffering: notEmpty('event.offering'),
+  clickable: any('isIlm', 'isOffering'),
+  
+  actions: {
+    selectEvent(event){
+      if(this.get('clickable')){
+        this.sendAction('action', event);
+      }
+    }
+  }
+});

--- a/addon/templates/components/ilios-calendar-multiday-event.hbs
+++ b/addon/templates/components/ilios-calendar-multiday-event.hbs
@@ -1,0 +1,5 @@
+{{moment-format event.startDate 'M/D/YY h:mma'}} - {{moment-format event.endDate 'M/D/YY h:mma'}} 
+<span {{action 'selectEvent' event}} class='{{if clickable "clickable"}}'>
+  {{event.name}} 
+</span> 
+{{event.location}}

--- a/addon/templates/components/ilios-calendar-multiday-events.hbs
+++ b/addon/templates/components/ilios-calendar-multiday-events.hbs
@@ -3,10 +3,7 @@
   <h4>{{multidayEvents}}</h4>
     <ul>
       {{#each events as |event|}}
-        <li >
-          {{moment-format event.startDate 'M/D/YY h:mma'}} - {{moment-format event.endDate 'M/D/YY h:mma'}} 
-          <span {{action 'selectEvent' event}} class='clickable'>{{event.name}} </span> {{event.location}}
-        </li>
+        {{ilios-calendar-multiday-event action='selectEvent' event=event}}
       {{/each}}
     </ul>
   </div>

--- a/app/components/ilios-calendar-multiday-event.js
+++ b/app/components/ilios-calendar-multiday-event.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-calendar/components/ilios-calendar-multiday-event';

--- a/tests/integration/components/ilios-calendar-multiday-event-test.js
+++ b/tests/integration/components/ilios-calendar-multiday-event-test.js
@@ -1,0 +1,63 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import moment from 'moment';
+import hbs from 'htmlbars-inline-precompile';
+
+let getEvent = function(){
+  return {
+    startDate: moment('1984-11-11').toDate(),
+    endDate: moment('1984-11-12').toDate(),
+    name: "Cheramie is born",
+    location: 'Lancaster, CA',
+  };
+};
+
+moduleForComponent('ilios-calendar-multiday-event', 'Integration | Component | ilios calendar multiday event', {
+  integration: true
+});
+
+test('event displays correctly', function(assert) {
+  let event = getEvent();
+  this.set('event', event);
+  assert.expect(4);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{ilios-calendar-multiday-event event=event}}`);
+  
+  assert.equal(this.$().text().search(/11\/11\/84/), 0);
+  assert.equal(this.$().text().search(/11\/12\/84/), 19);
+  assert.equal(this.$().text().search(/Cheramie is born/), 40);
+  assert.equal(this.$().text().search(/Lancaster, CA/), 60);
+  
+});
+
+test('action fires on click', function(assert) {
+  let event = getEvent();
+  event.offering = 1;
+  
+  this.set('event', event);
+  assert.expect(2);
+  this.render(hbs`{{ilios-calendar-multiday-event event=event action='handleAction'}}`);
+  assert.ok(this.$().text().search(/Cheramie is born/) > 0);
+  this.on('handleAction', (value) => {
+    assert.deepEqual(event, value);
+  });
+  
+  this.$('.clickable').click();
+});
+
+test('action does not fire for scheduled events', function(assert) {
+  let event = getEvent();
+  
+  this.set('event', event);
+  assert.expect(1);
+  this.render(hbs`{{ilios-calendar-multiday-event event=event action='handleAction'}}`);
+  assert.ok(this.$().text().search(/Cheramie is born/) > 0);
+  this.on('handleAction', () => {
+    //this should never get called
+    assert.ok(false);
+  });
+  
+  this.$('.clickable').click();
+});


### PR DESCRIPTION
This prevents students with less privileges from accessing the single
event view, which would shown data for a scheduled event.