### PR TITLE
added no content phrase, loader, tests

### DIFF
--- a/addon/components/ilios-calendar-single-event-objective-list.js
+++ b/addon/components/ilios-calendar-single-event-objective-list.js
@@ -1,37 +1,50 @@
 import Ember from 'ember';
 import layout from '../templates/components/ilios-calendar-single-event-objective-list';
+import DS from 'ember-data';
 
-const { computed, isEmpty } = Ember;
+const { computed, isEmpty, RSVP } = Ember;
+const { Promise } = RSVP;
+const { PromiseArray } = DS;
 
 export default Ember.Component.extend({
   layout,
-  objectives: [],
+
   domains: computed('objectives.@each.[title,domain]', function(){
-    let objectives = this.get('objectives');
-    if(isEmpty(objectives)){
-      return [];
-    }
-    let domainTitles = objectives.map(obj => {
-      return obj.domain.toString();
-    });
-    domainTitles = Ember.A(domainTitles).uniq();
-    let domains = domainTitles.map(title => {
-      let domain = {
-        title,
-        objectives: []
-      };
-      let objectives = this.get('objectives').filter(obj => {
-        return obj.domain.toString() === title;
-      }).map(obj => {
-        return obj.title;
+    let promiseDomains = new Promise((resolve) => {
+      this.get('objectives').then((objectives) => {
+        if (isEmpty(objectives)) {
+          resolve([]);
+          return;
+        }
+
+        let domainTitles = objectives.map(obj => {
+          return obj.domain.toString();
+        });
+
+        domainTitles = Ember.A(domainTitles).uniq();
+
+        let domains = domainTitles.map(title => {
+          let domain = {
+            title,
+            objectives: []
+          };
+          let filteredObjectives = objectives.filter(obj => {
+            return obj.domain.toString() === title;
+          }).map(obj => {
+            return obj.title;
+          });
+          domain.objectives = Ember.A(filteredObjectives).sortBy('title');
+
+          return domain;
+        });
+
+        resolve(Ember.A(domains).sortBy('title'));
       });
-      domain.objectives = Ember.A(objectives).sortBy('title');
-      
-      return domain;
     });
-    
-    
-    //make it an ennumerable so it can be observed
-    return Ember.A(domains).sortBy('title');
+
+    // Make it an ennumerable so it can be observed
+    return PromiseArray.create({
+      promise: promiseDomains
+    });
   }),
 });

--- a/addon/components/ilios-calendar-single-event.js
+++ b/addon/components/ilios-calendar-single-event.js
@@ -4,23 +4,24 @@ import layout from '../templates/components/ilios-calendar-single-event';
 export default Ember.Component.extend({
   layout,
   classNames: ['ilios-calendar', 'ilios-calendar-single-event'],
-  
+
   courseTitle: null,
   sessionTitle: null,
   description: null,
   offeredAtPhrase: null,
   taughtByPhrase: null,
   sessionIsPhrase: null,
-  
+  noContentPhrase: null,
+
   courseObjectivesPhrase: 'Course Objectives',
   courseLearningMaterialsPhrase: 'Course Learning Materials',
   courseObjectives: null,
   courseLearningMaterials: null,
-  
+
   sessionLearningMaterialsPhrase: 'Session Learning Materials',
   sessionObjectivesPhrase: 'Session Objectives',
   sessionLearningMaterials: null,
   sessionObjectives: null,
-  
-  requiredPhrase: 'Required',
+
+  requiredPhrase: 'Required'
 });

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -1,48 +1,76 @@
 .ilios-calendar .ilios-calendar-month .el-calendar .week {
   overflow-y: hidden;
-  padding-top: .25rem; }
+  padding-top: .25rem;
+}
+
 .ilios-calendar .ilios-calendar-month .el-calendar .day {
   border: 1px solid #eee;
   margin-right: .25rem;
   overflow-y: hidden;
-  padding: .25rem; }
-  .ilios-calendar .ilios-calendar-month .el-calendar .day .events {
-    height: 7rem;
-    overflow-y: auto;
-    padding-bottom: 4rem; }
+  padding: .25rem;
+}
+
+.ilios-calendar .ilios-calendar-month .el-calendar .day .events {
+  height: 7rem;
+  overflow-y: auto;
+  padding-bottom: 4rem;
+}
+
 .ilios-calendar .ilios-calendar-month .el-calendar .ilios-calendar-event.month-event {
   height: 1.5em;
   padding: 0;
-  position: relative; }
-  .ilios-calendar .ilios-calendar-month .el-calendar .ilios-calendar-event.month-event span {
-    background-color: transparent;
-    font-size: .5em;
-    font-weight: normal; }
-  .ilios-calendar .ilios-calendar-month .el-calendar .ilios-calendar-event.month-event .ilios-calendar-event-time {
-    color: #000;
-    display: inline; }
-  .ilios-calendar .ilios-calendar-month .el-calendar .ilios-calendar-event.month-event .ilios-calendar-event-end,
-  .ilios-calendar .ilios-calendar-month .el-calendar .ilios-calendar-event.month-event .ilios-calendar-event-location {
-    display: none; }
+  position: relative;
+}
+
+.ilios-calendar .ilios-calendar-month .el-calendar .ilios-calendar-event.month-event span {
+  background-color: transparent;
+  font-size: .5em;
+  font-weight: normal;
+}
+
+.ilios-calendar .ilios-calendar-month .el-calendar .ilios-calendar-event.month-event .ilios-calendar-event-time {
+  color: #000;
+  display: inline;
+}
+
+.ilios-calendar .ilios-calendar-month .el-calendar .ilios-calendar-event.month-event .ilios-calendar-event-end,
+.ilios-calendar .ilios-calendar-month .el-calendar .ilios-calendar-event.month-event .ilios-calendar-event-location {
+  display: none;
+}
+
 .ilios-calendar .ilios-calendar-week .el-calendar span {
-  font-size: .8em; }
+  font-size: .8em;
+}
+
 .ilios-calendar .ilios-calendar-week .el-calendar .ilios-calendar-event .ilios-calendar-event-end,
 .ilios-calendar .ilios-calendar-month .el-calendar .ilios-calendar-event .ilios-calendar-event-end {
-  display: none; }
+  display: none;
+}
+
 .ilios-calendar .ilios-calendar-day .el-calendar .ilios-calendar-event .ilios-calendar-event-location {
-  display: block; }
+  display: block;
+}
+
 .ilios-calendar .ilios-calendar-day .el-calendar .ilios-calendar-event .ilios-calendar-event-instructors {
   display: block;
-  font-size: 0.9em; }
+  font-size: 0.9em;
+}
+
 .ilios-calendar .ilios-calendar-day .el-calendar .ilios-calendar-event .ilios-calendar-event-coursetitle {
   display: block;
   font-size: 0.85em;
-  font-style: italic; }
+  font-style: italic;
+}
+
 .ilios-calendar .el-calendar .event {
   overflow: hidden;
-  position: absolute; }
+  position: absolute;
+}
+
 .ilios-calendar .el-calendar .event-column {
-  border-left: 1px solid #eee; }
+  border-left: 1px solid #eee;
+}
+
 .ilios-calendar .el-calendar .ilios-calendar-event {
   border-bottom: 3px solid #fff;
   color: #000;
@@ -273,103 +301,164 @@
   .ilios-calendar .el-calendar .ilios-calendar-event.workshop {
     background-color: #fe7a78;
     border-left: 4px solid #fd2f2c; }
+
 .ilios-calendar .ilios-calendar-event {
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
   background-color: #fbfbfb;
-  border: 1px solid #eee; }
+  border: 1px solid #eee;
+}
+
 .ilios-calendar .clickable {
   color: #009ccc;
-  cursor: pointer; }
+  cursor: pointer;
+}
+
 .ilios-calendar .ilios-calendar-calendar {
   clear: both;
-  position: relative; }
-  .ilios-calendar .ilios-calendar-calendar h1 {
-    left: 4em;
-    opacity: 75;
-    position: absolute;
-    top: 2em;
-    transition: all .5s ease-in-out; }
-    .ilios-calendar .ilios-calendar-calendar h1.loaded {
-      opacity: 0; }
+  position: relative;
+}
+
+.ilios-calendar .ilios-calendar-calendar h1 {
+  left: 4em;
+  opacity: 75;
+  position: absolute;
+  top: 2em;
+  transition: all .5s ease-in-out;
+}
+
+.ilios-calendar .ilios-calendar-calendar h1.loaded {
+  opacity: 0;
+}
+
 .ilios-calendar .calendar-view-picker {
-  float: right; }
-  .ilios-calendar .calendar-view-picker .highlight {
-    color: #c60;
-    font-size: 1.25em; }
-  .ilios-calendar .calendar-view-picker .on {
-    color: #84c444; }
+  float: right;
+}
+
+.ilios-calendar .calendar-view-picker .highlight {
+  color: #c60;
+  font-size: 1.25em;
+}
+
+.ilios-calendar .calendar-view-picker .on {
+  color: #84c444;
+}
+
 .ilios-calendar .calendar-time-picker {
-  float: left; }
+  float: left;
+}
+
 .ilios-calendar ul.inline, .ilios-calendar ul.inline li {
   display: inline;
-  margin-bottom: 1em; }
+  margin-bottom: 1em;
+}
+
 .ilios-calendar ul.inline li {
-  margin-right: 2em; }
+  margin-right: 2em;
+}
+
 .ilios-calendar .ilios-calendar-ics-feed {
   border: 1px dotted #c60;
   margin: auto;
   margin-bottom: 1em;
   padding: 2em;
-  width: 90%; }
-  .ilios-calendar .ilios-calendar-ics-feed input {
-    padding: .25em;
-    width: 80%; }
-  .ilios-calendar .ilios-calendar-ics-feed button {
-    background-color: #fff;
-    color: #009ccc;
-    margin-left: .5em;
-    padding: 0; }
+  width: 90%;
+}
+
+.ilios-calendar .ilios-calendar-ics-feed input {
+  padding: .25em;
+  width: 80%;
+}
+
+.ilios-calendar .ilios-calendar-ics-feed button {
+  background-color: #fff;
+  color: #009ccc;
+  margin-left: .5em;
+  padding: 0;
+}
 
 .ilios-calendar-single-event h2 {
-  font-weight: bold; }
+  font-weight: bold;
+}
+
 .ilios-calendar-single-event fieldset {
   border: 0;
   border-left: 3px solid #eee;
   float: left;
-  width: 45%; }
-  .ilios-calendar-single-event fieldset caption {
-    color: #009ccc;
-    font-weight: bold; }
+  width: 45%;
+}
+
+.ilios-calendar-single-event fieldset caption {
+  color: #009ccc;
+  font-weight: bold;
+}
+
 .ilios-calendar-single-event .ilios-calendar-single-event-summary h1 {
-  font-weight: normal; }
-  .ilios-calendar-single-event .ilios-calendar-single-event-summary h1 em {
-    font-style: normal;
-    font-weight: bold; }
+  font-weight: normal;
+}
+
+.ilios-calendar-single-event .ilios-calendar-single-event-summary h1 em {
+  font-style: normal;
+  font-weight: bold;
+}
+
 .ilios-calendar-single-event .ilios-calendar-single-event-offered-at {
-  font-weight: bold; }
+  font-weight: bold;
+}
+
 .ilios-calendar-single-event .ilios-calendar-single-event-instructors {
-  font-style: italic; }
+  font-style: italic;
+}
+
 .ilios-calendar-single-event .ilios-calendar-single-event-learningmaterial-filesize {
   font-size: .8em;
-  font-style: italic; }
+  font-style: italic;
+}
+
 .ilios-calendar-single-event ul.tree li {
-  font-weight: bold; }
+  font-weight: bold;
+}
+
 .ilios-calendar-single-event ul.tree ul {
   margin-bottom: 1em;
-  margin-left: 1em; }
-  .ilios-calendar-single-event ul.tree ul li {
-    font-weight: normal;
-    list-style-type: disc; }
+  margin-left: 1em;
+}
+
+.ilios-calendar-single-event ul.tree ul li {
+  font-weight: normal;
+  list-style-type: disc;
+}
 
 .ilios-calendar-single-event-learningmaterial-item-notes i {
   display: inline;
   font-size: .85em;
-  margin-right: 5px; }
+  margin-right: 5px;
+}
+
 .ilios-calendar-single-event-learningmaterial-item-notes p {
   display: inline;
   font-size: .85em;
-  font-style: italic; }
+  font-style: italic;
+}
 
 .ilios-calendar-multiday-events {
   border: 1px dotted #009ccc;
   margin-top: 1em;
-  padding: 1em 0; }
-  .ilios-calendar-multiday-events h4 {
-    font-size: 1.25em;
-    font-weight: bold;
-    margin-top: 0; }
-  .ilios-calendar-multiday-events ul {
-    margin-left: 1em; }
+  padding: 1em 0;
+}
+
+.ilios-calendar-multiday-events h4 {
+  font-size: 1.25em;
+  font-weight: bold;
+  margin-top: 0;
+}
+
+.ilios-calendar-multiday-events ul {
+  margin-left: 1em;
+}
+
+.no-content {
+  list-style-type: none;
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -600,7 +600,7 @@ $ilios-green: #84c444;
     }
 
   }
-  
+
 }
 
 
@@ -680,14 +680,18 @@ $ilios-green: #84c444;
   border: 1px dotted $ilios-blue;
   margin-top: 1em;
   padding: 1em 0;
-  
+
   h4 {
     font-size: 1.25em;
     font-weight: bold;
     margin-top: 0;
   }
-  
+
   ul {
     margin-left: 1em;
   }
+}
+
+.no-content {
+  list-style-type: none;
 }

--- a/addon/templates/components/ilios-calendar-single-event-learningmaterial-list.hbs
+++ b/addon/templates/components/ilios-calendar-single-event-learningmaterial-list.hbs
@@ -1,35 +1,43 @@
-<ul class='static-list fa-ul'>
-  {{#each proxiedLearningMaterials as |lm|}}
-    <li class='ilios-calendar-single-event-learningmaterial-item'>
-      {{fa-icon lm.icon listItem=true}}
+{{#if learningMaterials.isPending}}
+  {{fa-icon 'spinner' spin=true}}
+{{else}}
+  {{#if proxiedLearningMaterials}}
+    <ul class='static-list fa-ul'>
+      {{#each proxiedLearningMaterials as |lm|}}
+        <li class='ilios-calendar-single-event-learningmaterial-item'>
+          {{fa-icon lm.icon listItem=true}}
 
-      <div class='ilios-calendar-single-event-learningmaterial-item-title'>
-        {{#if lm.required}}
-          {{fa-icon 'star' title=requiredPhrase}}
-        {{/if}}
-        {{#if lm.url}}<a target='_blank' href='{{lm.url}}'>{{lm.title}}</a>{{else}}{{lm.title}}{{/if}}
-        <span class='ilios-calendar-single-event-learningmaterial-filesize'>
-          {{#if lm.filesize}} ({{filesize lm.filesize}}){{/if}}
-        </span>
-      </div>
+          <div class='ilios-calendar-single-event-learningmaterial-item-title'>
+            {{#if lm.required}}
+              {{fa-icon 'star' title=requiredPhrase}}
+            {{/if}}
+            {{#if lm.url}}<a target='_blank' href='{{lm.url}}'>{{lm.title}}</a>{{else}}{{lm.title}}{{/if}}
+            <span class='ilios-calendar-single-event-learningmaterial-filesize'>
+              {{#if lm.filesize}} ({{filesize lm.filesize}}){{/if}}
+            </span>
+          </div>
 
-      {{#if lm.citation}}
-        <div class='ilios-calendar-single-event-learningmaterial-item-citation'>
-          {{lm.citation}}
-        </div>
-      {{/if}}
+          {{#if lm.citation}}
+            <div class='ilios-calendar-single-event-learningmaterial-item-citation'>
+              {{lm.citation}}
+            </div>
+          {{/if}}
 
-      {{#if lm.description}}
-        <div class='ilios-calendar-single-event-learningmaterial-item-description'>
-          {{{lm.description}}}
-        </div>
-      {{/if}}
+          {{#if lm.description}}
+            <div class='ilios-calendar-single-event-learningmaterial-item-description'>
+              {{{lm.description}}}
+            </div>
+          {{/if}}
 
-      {{#if lm.notes}}
-        <div class='ilios-calendar-single-event-learningmaterial-item-notes'>
-          {{fa-icon 'pencil-square-o'}}<p>{{{lm.notes}}}</p>
-        </div>
-      {{/if}}
-    </li>
-  {{/each}}
-</ul>
+          {{#if lm.notes}}
+            <div class='ilios-calendar-single-event-learningmaterial-item-notes'>
+              {{fa-icon 'pencil-square-o'}}<p>{{{lm.notes}}}</p>
+            </div>
+          {{/if}}
+        </li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <li class="no-content">{{noContentPhrase}}</li>
+  {{/if}}
+{{/if}}

--- a/addon/templates/components/ilios-calendar-single-event-objective-list.hbs
+++ b/addon/templates/components/ilios-calendar-single-event-objective-list.hbs
@@ -1,11 +1,19 @@
-<ul class='tree'>
-  {{#each domains as |domain|}}
-    <li>{{domain.title}}
-      <ul>
-        {{#each domain.objectives as |title|}}
-          <li>{{{title}}}</li>
-        {{/each}}
-      </ul>
-    </li>
-  {{/each}}
-</ul>
+{{#if domains.isPending}}
+  {{fa-icon 'spinner' spin=true}}
+{{else}}
+  {{#if domains}}
+    <ul class='tree'>
+      {{#each domains as |domain|}}
+        <li>{{domain.title}}
+          <ul>
+            {{#each domain.objectives as |title|}}
+              <li>{{{title}}}</li>
+            {{/each}}
+          </ul>
+        </li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <li class="no-content">{{noContentPhrase}}</li>
+  {{/if}}
+{{/if}}

--- a/addon/templates/components/ilios-calendar-single-event.hbs
+++ b/addon/templates/components/ilios-calendar-single-event.hbs
@@ -1,7 +1,9 @@
 <div class='ilios-calendar-single-event-summary'>
   <h1>{{courseTitle}} - <em>{{sessionTitle}}</em></h1>
   <div class='ilios-calendar-single-event-offered-at'>{{offeredAtPhrase}}</div>
-  <div class='ilios-calendar-single-event-instructors'>{{taughtByPhrase}} {{listOfInstructors}}</div>
+  {{#if taughtByPhrase}}
+    <div class='ilios-calendar-single-event-instructors'>{{taughtByPhrase}}</div>
+  {{/if}}
   <div class='ilios-calendar-single-event-session-is'>{{sessionIsPhrase}}</div>
   {{#if description}}{{{description}}}<br />{{/if}}
 </div>
@@ -12,11 +14,14 @@
     {{ilios-calendar-single-event-learningmaterial-list
       learningMaterials=sessionLearningMaterials
       requiredPhrase=requiredPhrase
+      noContentPhrase=noContentPhrase
     }}
   </div>
   <div class='ilios-calendar-single-event-objective-list'>
     <h2>{{sessionObjectivesPhrase}}</h2>
-    {{ilios-calendar-single-event-objective-list objectives=sessionObjectives}}
+    {{ilios-calendar-single-event-objective-list
+      objectives=sessionObjectives
+      noContentPhrase=noContentPhrase}}
   </div>
 </fieldset>
 
@@ -26,10 +31,18 @@
     {{ilios-calendar-single-event-learningmaterial-list
       learningMaterials=courseLearningMaterials
       requiredPhrase=requiredPhrase
+      noContentPhrase=noContentPhrase
     }}
   </div>
   <div class='ilios-calendar-single-event-objective-list'>
     <h2>{{courseObjectivesPhrase}}</h2>
-    {{ilios-calendar-single-event-objective-list objectives=courseObjectives}}
+    {{#if courseObjectives.isFulfilled}}
+    {{ilios-calendar-single-event-objective-list
+      objectives=courseObjectives
+      noContentPhrase=noContentPhrase
+    }}
+    {{else}}
+      {{fa-icon 'spinner' spin=true}}
+    {{/if}}
   </div>
 </fieldset>

--- a/tests/integration/components/ilios-calendar-single-event-learningmaterial-list-test.js
+++ b/tests/integration/components/ilios-calendar-single-event-learningmaterial-list-test.js
@@ -13,11 +13,22 @@ test('it renders', function(assert) {
     {title: 'second one', mimetype: 'wav', url: 'http://secondlink'},
   ]);
   this.render(hbs`{{ilios-calendar-single-event-learningmaterial-list learningMaterials=learningMaterials}}`);
-  
+
   assert.equal(this.$('li:eq(0)').text().trim().search(/^first one/), 0);
   assert.equal(this.$('li:eq(0) a').attr('href').trim(), 'http://firstlink');
-  
+
   assert.equal(this.$('li:eq(1)').text().trim().search(/^second one/), 0);
   assert.equal(this.$('li:eq(1) a').attr('href').trim(), 'http://secondlink');
+});
+
+test('displays `None` when provided no content', function(assert) {
+  assert.expect(1);
+
+  this.set('learningMaterials', []);
+  this.render(hbs`{{ilios-calendar-single-event-learningmaterial-list
+    learningMaterials=learningMaterials
+    noContentPhrase='None'
+  }}`);
   
+  assert.equal(this.$('.no-content').text(), 'None');
 });

--- a/tests/integration/components/ilios-calendar-single-event-objective-list-test.js
+++ b/tests/integration/components/ilios-calendar-single-event-objective-list-test.js
@@ -1,5 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+const { RSVP } = Ember;
+const { Promise } = RSVP;
 
 moduleForComponent('ilios-calendar-single-event-objective-list', 'Integration | Component | ilios calendar single event objective list', {
   integration: true
@@ -7,16 +11,21 @@ moduleForComponent('ilios-calendar-single-event-objective-list', 'Integration | 
 
 test('it renders', function(assert) {
   assert.expect(4);
-  this.set('objectives', [
+
+  const array = [
     {domain: 'great things', title: 'cheese'},
     {domain: 'great things', title: 'ice cream'},
     {domain: 'annoying things', title: 'buying gas'},
     {domain: 'annoying things', title: 'traffic'},
-  ]);
+  ];
+
+  let objectives = Promise.resolve(array);
+
+  this.set('objectives', objectives);
   this.render(hbs`{{ilios-calendar-single-event-objective-list objectives=objectives}}`);
-  
-  assert.equal(this.$('ul:eq(0)>li:eq(0)').text().trim().search(/^annoying things/), 0);    
+
+  assert.equal(this.$('ul:eq(0)>li:eq(0)').text().trim().search(/^annoying things/), 0);
   assert.equal(this.$('ul:eq(0)>li:eq(0)>ul>li:eq(1)').text().trim().search(/^traffic/), 0);
-  assert.equal(this.$('ul:eq(0)>li:eq(1)').text().trim().search(/^great things/), 0);    
+  assert.equal(this.$('ul:eq(0)>li:eq(1)').text().trim().search(/^great things/), 0);
   assert.equal(this.$('ul:eq(0)>li:eq(1)>ul>li:eq(0)').text().trim().search(/^cheese/), 0);
 });

--- a/tests/integration/components/ilios-calendar-single-event-test.js
+++ b/tests/integration/components/ilios-calendar-single-event-test.js
@@ -1,38 +1,70 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+const { isEmpty, RSVP } = Ember;
+const { Promise } = RSVP;
 
 moduleForComponent('ilios-calendar-single-event', 'Integration | Component | ilios calendar single event', {
-  integration: true
-});
+  integration: true,
+  beforeEach() {
+    let objectives = new Promise((resolve) => {
+      const array = Ember.A([
+        {domain: 'great things', title: 'cheese'}
+      ]);
 
-test('it renders empty', function(assert) {
-  assert.expect(1);
-  this.render(hbs`{{ilios-calendar-single-event}}`);
-  assert.ok(this.$().text().trim().length > 0);
+      resolve(array);
+    });
+
+    this.setProperties({ courseObjectives: objectives, sessionObjectives: objectives });
+  }
 });
 
 test('setting course title changes display', function(assert) {
   assert.expect(1);
 
-  this.render(hbs`{{ilios-calendar-single-event courseTitle='Being a Champion'}}`);
+  this.render(hbs`{{ilios-calendar-single-event courseTitle='Being a Champion'
+    courseObjectives=courseObjectives
+    sessionObjectives=sessionObjectives
+  }}`);
   assert.equal(this.$().text().trim().search(/Being a Champion/), 0);
 });
 
 test('setting session title changes display', function(assert) {
   assert.expect(1);
 
-  this.render(hbs`{{ilios-calendar-single-event sessionTitle='Being a Champion'}}`);
+  this.render(hbs`{{ilios-calendar-single-event sessionTitle='Being a Champion'
+    courseObjectives=courseObjectives
+    sessionObjectives=sessionObjectives
+  }}`);
   assert.equal(this.$().text().trim().search(/- Being a Champion/), 0);
 });
 
 test('setting taughtBy changes display', function(assert) {
   assert.expect(1);
-  this.render(hbs`{{ilios-calendar-single-event taughtByPhrase='A swell guy, Dr. Famous'}}`);
+  this.render(hbs`{{ilios-calendar-single-event taughtByPhrase='A swell guy, Dr. Famous'
+    courseObjectives=courseObjectives
+    sessionObjectives=sessionObjectives
+  }}`);
   assert.notEqual(this.$().text().trim().search(/A swell guy, Dr. Famous/), -1);
 });
 
 test('setting sessionIsPhrase changes display', function(assert) {
   assert.expect(1);
-  this.render(hbs`{{ilios-calendar-single-event sessionIsPhrase='This is some good stuff!'}}`);
+  this.render(hbs`{{ilios-calendar-single-event sessionIsPhrase='This is some good stuff!'
+    courseObjectives=courseObjectives
+    sessionObjectives=sessionObjectives
+  }}`);
   assert.notEqual(this.$().text().trim().search(/This is some good stuff!/), -1);
+});
+
+test('taughtBy does not display', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{ilios-calendar-single-event taughtByPhrase=''
+    courseObjectives=courseObjectives
+    sessionObjectives=sessionObjectives
+  }}`);
+
+  assert.ok(isEmpty(this.$('.ilios-calendar-single-event-instructors')));
 });


### PR DESCRIPTION
Fixes https://github.com/ilios/frontend/issues/877 
Fixes https://github.com/ilios/frontend/issues/1338

App PR: https://github.com/ilios/frontend/pull/1351

On Proxy:
1) To verify no content phrase occurring when no content is available, `/events/S0120160130O72596`.
2) To verify loading status, `/events/S0120160121O62770`.
3) To verify if `Taught By` phrase is gone when instructors are empty, `/events/S0120160128O73151`.