### PR TITLE
Remove deprecated method

### DIFF
--- a/addon/components/ilios-calendar-event-month.js
+++ b/addon/components/ilios-calendar-event-month.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 
 const { computed, Handlebars, isBlank } = Ember;
 const { SafeString } = Handlebars;
-const { notEmpty, any } = computed;
+const { notEmpty, or } = computed;
 
 export default CalendarEvent.extend({
   layout,
@@ -57,7 +57,7 @@ export default CalendarEvent.extend({
   }),
   isIlm: notEmpty('event.ilmSession'),
   isOffering: notEmpty('event.offering'),
-  clickable: any('isIlm', 'isOffering'),
+  clickable: or('isIlm', 'isOffering'),
 
   daysToShowAlert: null,
 

--- a/addon/components/ilios-calendar-event.js
+++ b/addon/components/ilios-calendar-event.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 
 const { computed, Handlebars, isBlank, isArray } = Ember;
 const { SafeString } = Handlebars;
-const { notEmpty, any } = computed;
+const { notEmpty, or } = computed;
 
 export default CalendarEvent.extend({
   layout,
@@ -103,7 +103,7 @@ export default CalendarEvent.extend({
   }),
   isIlm: notEmpty('event.ilmSession'),
   isOffering: notEmpty('event.offering'),
-  clickable: any('isIlm', 'isOffering'),
+  clickable: or('isIlm', 'isOffering'),
 
   formattedInstructors: computed(function() {
     let instructors = this.get('event.instructors');

--- a/addon/components/ilios-calendar-multiday-event.js
+++ b/addon/components/ilios-calendar-multiday-event.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/ilios-calendar-multiday-event';
 
-const { notEmpty, any } = Ember.computed;
+const { notEmpty, or } = Ember.computed;
 
 export default Ember.Component.extend({
   layout: layout,
@@ -9,8 +9,8 @@ export default Ember.Component.extend({
   event: null,
   isIlm: notEmpty('event.ilmSession'),
   isOffering: notEmpty('event.offering'),
-  clickable: any('isIlm', 'isOffering'),
-  
+  clickable: or('isIlm', 'isOffering'),
+
   actions: {
     selectEvent(event){
       if(this.get('clickable')){


### PR DESCRIPTION
Ember.computed.any is deprecated and we need to use Ember.computed.or

If tests pass this is good to merge.