### PR TITLE
Update elemental-calendar to 0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "elemental-calendar": "0.0.7",
+    "elemental-calendar": "0.0.8",
     "ember-cli": "1.13.15",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-clipboard": "0.3.0",


### PR DESCRIPTION
Clears up some deprecation issues - no other changes.