### PR TITLE
Sort events for the calendar

### DIFF
--- a/addon/components/ilios-calendar.js
+++ b/addon/components/ilios-calendar.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 
 const { Component, computed, RSVP, copy } = Ember;
 const { PromiseArray } = DS;
+const { sort } = computed;
 
 export default Component.extend({
   layout,
@@ -58,6 +59,24 @@ export default Component.extend({
     return PromiseArray.create({
       promise: defer.promise
     });
+  }),
+  sortedCalendarEvents: sort('compiledCalendarEvents', function(a, b){
+    let startDiff = moment(a.startDate).diff(moment(b.startDate));
+    if (startDiff !== 0) {
+      return startDiff;
+    }
+
+    let durrationA = moment(a.startDate).diff(moment(a.endDate));
+    let durrationB = moment(b.startDate).diff(moment(b.endDate));
+
+    let durationDiff = durrationA - durrationB;
+
+    if (durationDiff !== 0) {
+      return durationDiff;
+    }
+
+    return a.title - b.title;
+
   }),
   actions: {
     changeView(newView){

--- a/addon/templates/components/ilios-calendar.hbs
+++ b/addon/templates/components/ilios-calendar.hbs
@@ -16,7 +16,7 @@
   {{/if}}
   <h1 class="{{if compiledCalendarEvents.isFulfilled 'loaded'}}">{{fa-icon 'spinner' spin=true}} {{loadingMessage}}</h1>
   {{component (concat "ilios-calendar-" selectedView)
-    calendarEvents=compiledCalendarEvents.content
+    calendarEvents=sortedCalendarEvents
     date=selectedDate
     selectEvent='selectEvent'
     changeDate='changeDate'

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -63,6 +63,15 @@ export default Controller.extend({
       events.pushObject(smallGroupsEvent);
     }
 
+    let sortedMonthStartDate = moment().add(7, 'day').hour(10);
+    for(let i = 5; i > 0; i--) {
+      let thisEvent = this.createUserEventObject();
+      thisEvent.startDate = sortedMonthStartDate.clone().add(i, 'minutes');
+      thisEvent.name = 'Session: ' + i;
+      thisEvent.endDate = thisEvent.startDate.clone().add(1, 'hour');
+      events.pushObject(thisEvent);
+    }
+
     let promise = RSVP.resolve(events);
     return PromiseArray.create({
       promise: promise


### PR DESCRIPTION
We were relying on events to be sorted by the API, this ensures that
does not matter.

Events are sorted first by start date, then by duration, then by title.  This matches what MS Outlook seems to do.

Fixes #14