### PR TITLE
Use new ember-tooltips method for creating tooltips

### DIFF
--- a/addon/templates/components/ilios-calendar-event-month.hbs
+++ b/addon/templates/components/ilios-calendar-event-month.hbs
@@ -1,4 +1,7 @@
 {{#if event}}
+  {{#tooltip-on-component}}
+    {{{tooltipContent}}}
+  {{/tooltip-on-component}}
   {{#if recentlyUpdated}}
     {{fa-icon 'exclamation' class="recently-updated-icon"}}
   {{/if}}

--- a/addon/templates/components/ilios-calendar-event.hbs
+++ b/addon/templates/components/ilios-calendar-event.hbs
@@ -1,50 +1,55 @@
 {{#if event}}
-  {{#if recentlyUpdated}}
-    {{fa-icon 'exclamation-circle' class="recently-updated-icon"}}
-  {{/if}}
-
-  {{#unless isMonth}}
-      {{#if event.isScheduled}}
-        {{fa-icon 'files-o'}}
-      {{/if}}
-  {{/unless}}
-
-  <span class='ilios-calendar-event-time'>
-    {{#if isIlm}}
-      <span class='ilios-calendar-event-start'>
-        ILM - Due: {{moment-format event.startDate 'h:mma'}}
-      </span>
-    {{else}}
-      <span class='ilios-calendar-event-start'>
-        {{moment-format event.startDate 'h:mma'}}
-      </span>
-      <span class='ilios-calendar-event-end'>
-        - {{moment-format event.endDate 'h:mma'}}
-      </span>
+  <div>
+    {{#tooltip-on-element}}
+      {{{tooltipContent}}}
+    {{/tooltip-on-element}}
+    {{#if recentlyUpdated}}
+      {{fa-icon 'exclamation-circle' class="recently-updated-icon"}}
     {{/if}}
-  </span>
 
-  {{#unless event.isMulti}}
-    <span class='ilios-calendar-event-location'>
-      {{#if event.location.length}}
-        {{event.location}}:
+    {{#unless isMonth}}
+        {{#if event.isScheduled}}
+          {{fa-icon 'files-o'}}
+        {{/if}}
+    {{/unless}}
+
+    <span class='ilios-calendar-event-time'>
+      {{#if isIlm}}
+        <span class='ilios-calendar-event-start'>
+          ILM - Due: {{moment-format event.startDate 'h:mma'}}
+        </span>
+      {{else}}
+        <span class='ilios-calendar-event-start'>
+          {{moment-format event.startDate 'h:mma'}}
+        </span>
+        <span class='ilios-calendar-event-end'>
+          - {{moment-format event.endDate 'h:mma'}}
+        </span>
       {{/if}}
     </span>
-  {{/unless}}
 
-  <span class='ilios-calendar-event-name'>
-    {{event.name}}{{#if event.isMulti}}, <em>{{multiplePhrase}}</em>{{/if}}
-  </span>
-  {{! list instructors in day view, if available }}
-  {{#if isDay}}
-    {{#if event.instructors}}
-      <span class="ilios-calendar-event-instructors">
-        {{taughtByPhrase}}
-        {{formattedInstructors}}
+    {{#unless event.isMulti}}
+      <span class='ilios-calendar-event-location'>
+        {{#if event.location.length}}
+          {{event.location}}:
+        {{/if}}
       </span>
+    {{/unless}}
+
+    <span class='ilios-calendar-event-name'>
+      {{event.name}}{{#if event.isMulti}}, <em>{{multiplePhrase}}</em>{{/if}}
+    </span>
+    {{! list instructors in day view, if available }}
+    {{#if isDay}}
+      {{#if event.instructors}}
+        <span class="ilios-calendar-event-instructors">
+          {{taughtByPhrase}}
+          {{formattedInstructors}}
+        </span>
+      {{/if}}
+      {{#if event.courseTitle}}
+        <span class="ilios-calendar-event-coursetitle">{{event.courseTitle}}</span>
+      {{/if}}
     {{/if}}
-    {{#if event.courseTitle}}
-      <span class="ilios-calendar-event-coursetitle">{{event.courseTitle}}</span>
-    {{/if}}
-  {{/if}}
+  </div>
 {{/if}}

--- a/package.json
+++ b/package.json
@@ -42,8 +42,10 @@
     "ember-load-initializers": "^0.5.1",
     "ember-moment": "6.1.0",
     "ember-resolver": "^2.0.3",
-    "ember-tooltips": "^0.7.0",
-    "loader.js": "^4.0.1"
+    "ember-tether": "0.3.1",
+    "ember-tooltips": "1.0.0",
+    "ember-try": "~0.0.8",
+    "loader.js": "^4.0.0"
   },
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "ember-cli-clipboard": "0.3.2",
     "ember-cli-content-security-policy": "0.5.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-font-awesome": "2.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-moment-shim": "1.3.0",
@@ -39,12 +38,13 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
+    "ember-font-awesome": "2.1.1",
     "ember-load-initializers": "^0.5.1",
     "ember-moment": "6.1.0",
     "ember-resolver": "^2.0.3",
     "ember-tether": "0.3.1",
     "ember-tooltips": "1.0.0",
-    "ember-try": "~0.0.8",
+    "ember-try": "0.2.2",
     "loader.js": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
Events needed to get a top level element otherwise the tip wasn't
hovering over the event.  Probably because the location gets bounced
around by the style too much.