### PR TITLE
upgrade to Ember CLI 2.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "4"
 
 sudo: false
 
 cache:
   directories:
     - node_modules
-    - bower_components
 
 env:
-  - EMBER_TRY_SCENARIO=default
+  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-1.13
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ Provides the ilios calendar addon to other ember applications including our fron
 
 ## Installation
 
-* `git clone` this repository
+* `git clone <repository-url>` this repository
+* `cd ilios-calendar`
 * `npm install`
 * `bower install`
 
 ## Running
 
-* `ember server`
-* Visit your app at http://localhost:4200.
+* `ember serve`
+* Visit your app at [http://localhost:4200](http://localhost:4200).
 
 ## Running Tests
 
-* `npm test` (Runs `ember try:testall` to test your addon against multiple Ember versions)
+* `npm test` (Runs `ember try:each` to test your addon against multiple Ember versions)
 * `ember test`
 * `ember test --server`
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ilios-calendar",
   "dependencies": {
-    "ember": "~2.9.0-beta.1",
+    "ember": "~2.9.0",
     "moment": ">= 2.8.0",
     "moment-timezone": ">= 0.1.0",
     "font-awesome": "~4.5.0",

--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "ilios-calendar",
   "dependencies": {
-    "ember": "~2.8.0",
+    "ember": "~2.9.0-beta.1",
     "moment": ">= 2.8.0",
     "moment-timezone": ">= 0.1.0",
     "font-awesome": "~4.5.0",
     "clipboard": "~1.5.5",
-    "ember-cli-shims": "0.1.1"
+    "ember-cli-shims": "0.1.3"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 /*eslint-env node*/
 module.exports = {
+  scenarios: [
     {
       name: 'ember-1.13',
       bower: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,12 +1,5 @@
 /*eslint-env node*/
 module.exports = {
-  scenarios: [
-    {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
-    },
     {
       name: 'ember-1.13',
       bower: {
@@ -15,6 +8,17 @@ module.exports = {
         },
         resolutions: {
           'ember': '~1.13.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.4',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
         }
       }
     },

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,6 @@
 /*eslint-env node*/
+'use strict';
+
 module.exports = function(/* environment, appConfig */) {
-  return {};
+  return { };
 };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 /*eslint-env node*/
+'use strict';
+
 module.exports = {
   isDevelopingAddon: function() {
     return false;

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "ember-cli": "2.9.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-clipboard": "0.4.1",
-    "ember-cli-dependency-checker": "^1.2.0",
+    "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "3.0.0",
+    "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.5",
-    "ember-cli-inject-live-reload": "^1.4.0",
+    "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-moment-shim": "2.2.1",
     "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
@@ -36,7 +37,7 @@
     "ember-cli-template-lint": "0.4.12",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.8.0",
+    "ember-data": "^2.9.0-beta.1",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
@@ -48,13 +49,13 @@
     "ember-tooltips": "2.3.1",
     "ember-truth-helpers": "1.2.0",
     "eslint": "^3.3.0",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.10"
   },
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.0",
     "ember-cli-sass": "^5.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "ember-cli-clipboard": "0.4.1",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "3.0.0",
-    "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.5",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-moment-shim": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-cli-template-lint": "0.4.12",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.9.0-beta.1",
+    "ember-data": "^2.9.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "broccoli-asset-rev": "^2.4.6",
     "elemental-calendar": "0.0.9",
     "ember-ajax": "2.5.2",
-    "ember-cli": "2.8.0",
+    "ember-cli": "2.9.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-clipboard": "0.4.1",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -9,6 +9,10 @@ module.exports = function(environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
       }
     },
 
@@ -37,5 +41,10 @@ module.exports = function(environment) {
     ENV.APP.rootElement = '#ember-testing';
   }
 
+  /*
+  if (environment === 'production') {
+
+  }
+  */
   return ENV;
 };

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,7 +21,7 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="{{rootURL}}testem.js" integrity=""></script>
+    <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>


### PR DESCRIPTION
I ran the [Project Update](https://github.com/ember-cli/ember-cli/releases/tag/v2.9.0) instructions for the latest Ember CLI release, and the merged, kept or reverted any file changes introduced by `ember init` as applicable.
