### PR TITLE
Improve month view by limiting events displayed

### DIFF
--- a/addon/components/ilios-calendar-month.js
+++ b/addon/components/ilios-calendar-month.js
@@ -6,6 +6,7 @@ export default Ember.Component.extend({
   layout: layout,
   date: null,
   calendarEvents: [],
+  showMore: null,
   actions: {
     selectEvent(event){
       this.sendAction('selectEvent', event);
@@ -17,6 +18,6 @@ export default Ember.Component.extend({
     changeToEventsDayView(event){
       this.sendAction('changeDate', event.startDate);
       this.sendAction('changeView', 'day');
-    }
+    },
   }
 });

--- a/addon/components/ilios-calendar.js
+++ b/addon/components/ilios-calendar.js
@@ -22,6 +22,7 @@ export default Component.extend({
   dueThisDay: 'Due this day',
   icsInstructions: 'To add your Ilios calendar to another application or service, use this URL.  This URL is like a password. Anyone who knows it can view your calendar! If you wish to invalidate this URL and generate a new one, press the refresh button.',
   multidayEvents: 'Multiday Events',
+  showMore: 'Show more',
   showIcsFeed: false,
   compiledCalendarEvents: computed('calendarEventsPromise.[]', 'selectedView', function(){
     let defer = RSVP.defer();

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -41,10 +41,12 @@ $updated-color: #945c58;
   border-top-left-radius: $radii;
 }
 
+
 // scss-lint:disable NestingDepth SelectorDepth
 .ilios-calendar {
 
   .ilios-calendar-month {
+    min-height: 25em;
 
     .el-calendar {
 
@@ -60,9 +62,8 @@ $updated-color: #945c58;
         padding: .25rem;
 
         .events {
-          height: 7rem;
-          overflow-y: auto;
-          padding-bottom: 4rem;
+          height: 4rem;
+          padding-bottom: 2rem;
         }
       }
 
@@ -86,6 +87,13 @@ $updated-color: #945c58;
         .ilios-calendar-event-location {
           display: none;
         }
+      }
+
+      .month-more-events {
+        display: block;
+        font-size: .8em;
+        text-align: right;
+        width: 100%;
       }
     }
   }

--- a/addon/templates/components/ilios-calendar-month.hbs
+++ b/addon/templates/components/ilios-calendar-month.hbs
@@ -21,13 +21,24 @@
             {{formatted-date day.date type='monthly-day'}}
           </span>
           <div class="events">
-            {{#each day.events as |event|}}
-              {{#if event.isMulti}}
-                {{ilios-calendar-event-month event=event action='changeToEventsDayView' dueThisDay=dueThisDay}}
-              {{else}}
-                {{ilios-calendar-event-month event=event action='selectEvent' dueThisDay=dueThisDay}}
-              {{/if}}
-            {{/each}}
+            {{#if (gt day.events.length 2)}}
+              {{#each (slice 0 2 day.events) as |event|}}
+                {{#if event.isMulti}}
+                  {{ilios-calendar-event-month event=event action='changeToEventsDayView' dueThisDay=dueThisDay}}
+                {{else}}
+                  {{ilios-calendar-event-month event=event action='selectEvent' dueThisDay=dueThisDay}}
+                {{/if}}
+              {{/each}}
+              <span {{action 'changeToDayView' day.date}} class=' clickable link month-more-events'>{{fa-icon 'ellipse-h'}} {{showMore}} {{fa-icon 'angle-double-down'}}</span>
+            {{else}}
+              {{#each day.events as |event|}}
+                {{#if event.isMulti}}
+                  {{ilios-calendar-event-month event=event action='changeToEventsDayView' dueThisDay=dueThisDay}}
+                {{else}}
+                  {{ilios-calendar-event-month event=event action='selectEvent' dueThisDay=dueThisDay}}
+                {{/if}}
+              {{/each}}
+            {{/if}}
           </div>
         </div>
       {{/each}}

--- a/addon/templates/components/ilios-calendar.hbs
+++ b/addon/templates/components/ilios-calendar.hbs
@@ -22,6 +22,7 @@
     changeDate='changeDate'
     changeView='changeView'
     dueThisDay=dueThisDay
+    showMore=showMore
     multidayEvents=multidayEvents
   }}
 </div>

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-cli-template-lint": "0.4.12",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-composable-helpers": "1.1.2",
     "ember-data": "^2.9.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",

--- a/tests/integration/components/ilios-calendar-month-test.js
+++ b/tests/integration/components/ilios-calendar-month-test.js
@@ -1,19 +1,69 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
 
 moduleForComponent('ilios-calendar-month', 'Integration | Component | ilios calendar month', {
   integration: true
 });
 
-test('month displays', function(assert) {
-  assert.expect(2);
-  let date = new Date('2015-09-30T12:00:00');
-  this.set('date', date);
+test('month displays with three events', function(assert) {
+  assert.expect(4);
+  let date = moment(new Date('2015-09-30T12:00:00'));
 
-  this.render(hbs`{{ilios-calendar-month date=date}}`);
+  this.set('date', date.toDate());
+
+  let firstEvent = createUserEventObject();
+  firstEvent.name = 'Some new thing';
+  firstEvent.startDate = date.clone();
+  firstEvent.endDate = date.clone().add(1, 'hour');
+
+  let secondEvent = createUserEventObject();
+  secondEvent.name = 'Second new thing';
+  secondEvent.startDate = date.clone().add(1, 'hour');
+  secondEvent.endDate = date.clone().add(3, 'hour');
+
+  let thirdEvent = createUserEventObject();
+  thirdEvent.name = 'Third new thing';
+  thirdEvent.startDate = date.clone().add(3, 'hour');
+  thirdEvent.endDate = date.clone().add(4, 'hour');
+
+  this.set('events', [firstEvent, secondEvent, thirdEvent]);
+  const events = '.event';
+  const more = '.month-more-events';
+
+  this.render(hbs`{{ilios-calendar-month date=date calendarEvents=events showMore='Show More'}}`);
   //Date input is Wednesday, Septrmber 30th.  Should be the first string
   assert.equal(this.$().text().trim().search(/^September 2015/), 0);
-  assert.equal(this.$('.event').length, 0);
+  assert.equal(this.$(events).length, 2);
+  assert.equal(this.$(more).length, 1);
+  assert.equal(this.$(more).text().trim(), 'Show More');
+});
+
+test('month displays with two events', function(assert) {
+  assert.expect(3);
+  let date = moment(new Date('2015-09-30T12:00:00'));
+
+  this.set('date', date.toDate());
+
+  let firstEvent = createUserEventObject();
+  firstEvent.name = 'Some new thing';
+  firstEvent.startDate = date.clone();
+  firstEvent.endDate = date.clone().add(1, 'hour');
+
+  let secondEvent = createUserEventObject();
+  secondEvent.name = 'Second new thing';
+  secondEvent.startDate = date.clone().add(1, 'hour');
+  secondEvent.endDate = date.clone().add(3, 'hour');
+
+  this.set('events', [firstEvent, secondEvent]);
+  const events = '.event';
+  const more = '.month-more-events';
+
+  this.render(hbs`{{ilios-calendar-month date=date calendarEvents=events showMore='Show More'}}`);
+  //Date input is Wednesday, Septrmber 30th.  Should be the first string
+  assert.equal(this.$().text().trim().search(/^September 2015/), 0);
+  assert.equal(this.$(events).length, 2);
+  assert.equal(this.$(more).length, 0);
 });
 
 test('clicking on a day fires the correct event', function(assert) {
@@ -25,6 +75,7 @@ test('clicking on a day fires the correct event', function(assert) {
     date=date
     changeDate='changeDate'
     changeView='changeView'
+    calendarEvents=events
   }}`);
   this.on('changeDate', newDate => {
     assert.ok(newDate instanceof Date);
@@ -35,3 +86,18 @@ test('clicking on a day fires the correct event', function(assert) {
   });
   this.$('.day .clickable').eq(0).click();
 });
+
+let createUserEventObject = function(){
+  return {
+    user: 1,
+    name: '',
+    offering: 1,
+    startDate: null,
+    endDate: null,
+    eventClass: 'peer-teaching',
+    location: 'Rm. 160',
+    lastModified: new Date(),
+    isPublished: true,
+    isScheduled: false
+  };
+};


### PR DESCRIPTION
Instead of trying to fit in all of the events in a day of the month view
just show two.  If there are more than 2 then display 'Show More' which
links to the day view.

Fixes #47