### PR TITLE
Use closure actions across the board

### DIFF
--- a/addon/components/ilios-calendar-day.js
+++ b/addon/components/ilios-calendar-day.js
@@ -32,9 +32,4 @@ export default Ember.Component.extend({
       event => !moment(event.startDate).isSame(moment(event.endDate), 'day')
     );
   }),
-  actions: {
-    selectEvent(event){
-      this.sendAction('selectEvent', event);
-    }
-  }
 });

--- a/addon/components/ilios-calendar-event-month.js
+++ b/addon/components/ilios-calendar-event-month.js
@@ -35,7 +35,7 @@ export default CalendarEvent.extend(TooltipContent, {
 
   click(){
     if(this.get('clickable')){
-      this.sendAction('action', this.get('event'));
+      this.get('selectEvent')();
     }
   }
 });

--- a/addon/components/ilios-calendar-event.js
+++ b/addon/components/ilios-calendar-event.js
@@ -73,7 +73,7 @@ export default CalendarEvent.extend(TooltipContent, {
 
   click(){
     if(this.get('clickable')){
-      this.sendAction('action', this.get('event'));
+      this.get('selectEvent')();
     }
   }
 });

--- a/addon/components/ilios-calendar-month.js
+++ b/addon/components/ilios-calendar-month.js
@@ -8,16 +8,9 @@ export default Ember.Component.extend({
   calendarEvents: [],
   showMore: null,
   actions: {
-    selectEvent(event){
-      this.sendAction('selectEvent', event);
-    },
     changeToDayView(date){
-      this.sendAction('changeDate', date);
-      this.sendAction('changeView', 'day');
-    },
-    changeToEventsDayView(event){
-      this.sendAction('changeDate', event.startDate);
-      this.sendAction('changeView', 'day');
+      this.get('changeDate')(date);
+      this.get('changeView')('day');
     },
   }
 });

--- a/addon/components/ilios-calendar-multiday-event.js
+++ b/addon/components/ilios-calendar-multiday-event.js
@@ -10,11 +10,10 @@ export default Ember.Component.extend({
   isIlm: notEmpty('event.ilmSession'),
   isOffering: notEmpty('event.offering'),
   clickable: or('isIlm', 'isOffering'),
-
   actions: {
-    selectEvent(event){
-      if(this.get('clickable')){
-        this.sendAction('action', event);
+    selectEvent(){
+      if (this.get('clickable')) {
+        this.get('selectEvent')();
       }
     }
   }

--- a/addon/components/ilios-calendar-multiday-events.js
+++ b/addon/components/ilios-calendar-multiday-events.js
@@ -3,11 +3,6 @@ import layout from '../templates/components/ilios-calendar-multiday-events';
 
 export default Ember.Component.extend({
   layout,
-  events: [],
+  events: null,
   multidayEvents: null,
-  actions: {
-    selectEvent(event){
-      this.sendAction('selectEvent', event);
-    },
-  }
 });

--- a/addon/components/ilios-calendar-week.js
+++ b/addon/components/ilios-calendar-week.js
@@ -37,16 +37,9 @@ export default Component.extend({
     );
   }),
   actions: {
-    selectEvent(event){
-      this.sendAction('selectEvent', event);
-    },
     changeToDayView(date){
-      this.sendAction('changeDate', date);
-      this.sendAction('changeView', 'day');
-    },
-    changeToEventsDayView(event){
-      this.sendAction('changeDate', event.startDate);
-      this.sendAction('changeView', 'day');
+      this.get('changeDate')(date);
+      this.get('changeView')('day');
     }
   }
 });

--- a/addon/components/ilios-calendar.js
+++ b/addon/components/ilios-calendar.js
@@ -80,33 +80,27 @@ export default Component.extend({
 
   }),
   actions: {
-    changeView(newView){
-      this.sendAction('changeView', newView);
-    },
     changeDate(newDate){
-      this.sendAction('changeDate', newDate);
+      this.get('changeDate')(newDate);
     },
     goForward(){
       let newDate = moment(this.get('selectedDate')).add(1, this.get('selectedView')).toDate();
-      this.sendAction('changeDate', newDate);
+      this.get('changeDate')(newDate);
     },
     goBack(){
       let newDate = moment(this.get('selectedDate')).subtract(1, this.get('selectedView')).toDate();
-      this.sendAction('changeDate', newDate);
+      this.get('changeDate')(newDate);
     },
     gotoToday(){
       let newDate = moment().toDate();
-      this.sendAction('changeDate', newDate);
+      this.get('changeDate')(newDate);
     },
     selectEvent(event){
-      this.sendAction('selectEvent', event);
-    },
-    toggleIcsFeed(){
-      this.set('showIcsFeed', !this.get('showIcsFeed'));
+      this.get('selectEvent')(event);
     },
     refreshIcsFeed(){
       this.set('icsFeedUrl', null);
-      this.sendAction('refreshIcsFeed');
+      this.get('refreshIcsFeed')();
     }
   }
 });

--- a/addon/templates/components/ilios-calendar-day.hbs
+++ b/addon/templates/components/ilios-calendar-day.hbs
@@ -17,7 +17,7 @@
       <li class="event-column">
         {{#each hours as |hour|}}
           {{#each hour.events as |event|}}
-            {{ilios-calendar-event event=event action='selectEvent' dueThisDay=dueThisDay isDay=true}}
+            {{ilios-calendar-event event=event selectEvent=(action selectEvent event) dueThisDay=dueThisDay isDay=true}}
           {{/each}}
         {{/each}}
       </li>
@@ -30,4 +30,4 @@
   </div>
 {{/el-daily-calendar}}
 
-{{ilios-calendar-multiday-events multidayEvents=multidayEvents events=multiDayEventsList selectEvent='selectEvent'}}
+{{ilios-calendar-multiday-events multidayEvents=multidayEvents events=multiDayEventsList selectEvent=(action selectEvent event)}}

--- a/addon/templates/components/ilios-calendar-month.hbs
+++ b/addon/templates/components/ilios-calendar-month.hbs
@@ -24,18 +24,18 @@
             {{#if (gt day.events.length 2)}}
               {{#each (slice 0 2 day.events) as |event|}}
                 {{#if event.isMulti}}
-                  {{ilios-calendar-event-month event=event action='changeToEventsDayView' dueThisDay=dueThisDay}}
+                  {{ilios-calendar-event-month event=event selectEvent=(action changeToDayView event.startDate) dueThisDay=dueThisDay}}
                 {{else}}
-                  {{ilios-calendar-event-month event=event action='selectEvent' dueThisDay=dueThisDay}}
+                  {{ilios-calendar-event-month event=event selectEvent=(action selectEvent event) dueThisDay=dueThisDay}}
                 {{/if}}
               {{/each}}
               <span {{action 'changeToDayView' day.date}} class=' clickable link month-more-events'>{{fa-icon 'ellipse-h'}} {{showMore}} {{fa-icon 'angle-double-down'}}</span>
             {{else}}
               {{#each day.events as |event|}}
                 {{#if event.isMulti}}
-                  {{ilios-calendar-event-month event=event action='changeToEventsDayView' dueThisDay=dueThisDay}}
+                  {{ilios-calendar-event-month event=event selectEvent=(action changeToDayView event.startDate) dueThisDay=dueThisDay}}
                 {{else}}
-                  {{ilios-calendar-event-month event=event action='selectEvent' dueThisDay=dueThisDay}}
+                  {{ilios-calendar-event-month event=event selectEvent=(action selectEvent event) dueThisDay=dueThisDay}}
                 {{/if}}
               {{/each}}
             {{/if}}

--- a/addon/templates/components/ilios-calendar-multiday-event.hbs
+++ b/addon/templates/components/ilios-calendar-multiday-event.hbs
@@ -1,5 +1,5 @@
-{{moment-format event.startDate 'M/D/YY h:mma'}} - {{moment-format event.endDate 'M/D/YY h:mma'}} 
-<span {{action 'selectEvent' event}} class='{{if clickable "clickable"}}'>
-  {{event.name}} 
-</span> 
+{{moment-format event.startDate 'M/D/YY h:mma'}} - {{moment-format event.endDate 'M/D/YY h:mma'}}
+<span {{action 'selectEvent'}} class='{{if clickable "clickable"}}'>
+  {{event.name}}
+</span>
 {{event.location}}

--- a/addon/templates/components/ilios-calendar-multiday-events.hbs
+++ b/addon/templates/components/ilios-calendar-multiday-events.hbs
@@ -3,7 +3,7 @@
     <h4>{{multidayEvents}}</h4>
     <ul>
       {{#each events as |event|}}
-        {{ilios-calendar-multiday-event action='selectEvent' event=event}}
+        {{ilios-calendar-multiday-event selectEvent=selectEvent event=event}}
       {{/each}}
     </ul>
   </div>

--- a/addon/templates/components/ilios-calendar-week.hbs
+++ b/addon/templates/components/ilios-calendar-week.hbs
@@ -25,9 +25,9 @@
         <li class="event-column">
           {{#each day.events as |event|}}
             {{#if event.isMulti}}
-              {{ilios-calendar-event event=event action='changeToEventsDayView' dueThisDay=dueThisDay}}
+              {{ilios-calendar-event event=event selectEvent=(action 'changeToDayView' event.startDate) dueThisDay=dueThisDay}}
             {{else}}
-              {{ilios-calendar-event event=event action='selectEvent' dueThisDay=dueThisDay}}
+              {{ilios-calendar-event event=event selectEvent=(action selectEvent event) dueThisDay=dueThisDay}}
             {{/if}}
           {{/each}}
         </li>
@@ -41,4 +41,4 @@
   </div>
 {{/el-weekly-calendar}}
 
-{{ilios-calendar-multiday-events multidayEvents=multidayEvents events=multiDayEventsList selectEvent='selectEvent'}}
+{{ilios-calendar-multiday-events multidayEvents=multidayEvents events=multiDayEventsList selectEvent=selectEvent}}

--- a/addon/templates/components/ilios-calendar.hbs
+++ b/addon/templates/components/ilios-calendar.hbs
@@ -1,8 +1,8 @@
 <ul class='inline calendar-view-picker'>
-  <li class='clickable highlight {{if showIcsFeed "on"}}' {{action 'toggleIcsFeed'}}>{{fa-icon 'feed'}}</li>
-  <li class='clickable' {{action 'changeView' 'day'}}>{{day}}</li>
-  <li class='clickable' {{action 'changeView' 'week'}}>{{week}}</li>
-  <li class='clickable' {{action 'changeView' 'month'}}>{{month}}</li>
+  <li class='clickable highlight {{if showIcsFeed "on"}}' {{action (toggle 'showIcsFeed' this)}}>{{fa-icon 'feed'}}</li>
+  <li class='clickable' {{action changeView 'day'}}>{{day}}</li>
+  <li class='clickable' {{action changeView 'week'}}>{{week}}</li>
+  <li class='clickable' {{action changeView 'month'}}>{{month}}</li>
 </ul>
 
 <ul class='inline calendar-time-picker'>
@@ -12,15 +12,15 @@
 </ul>
 <div class='ilios-calendar-calendar'>
   {{#if showIcsFeed}}
-    {{ics-feed url=icsFeedUrl instructions=icsInstructions refresh='refreshIcsFeed'}}
+    {{ics-feed url=icsFeedUrl instructions=icsInstructions refresh=refreshIcsFeed}}
   {{/if}}
   <h1 class="{{if compiledCalendarEvents.isFulfilled 'loaded'}}">{{fa-icon 'spinner' spin=true}} {{loadingMessage}}</h1>
   {{component (concat "ilios-calendar-" selectedView)
     calendarEvents=sortedCalendarEvents
     date=selectedDate
-    selectEvent='selectEvent'
-    changeDate='changeDate'
-    changeView='changeView'
+    selectEvent=selectEvent
+    changeDate=changeDate
+    changeView=changeView
     dueThisDay=dueThisDay
     showMore=showMore
     multidayEvents=multidayEvents

--- a/tests/integration/components/ilios-calendar-day-test.js
+++ b/tests/integration/components/ilios-calendar-day-test.js
@@ -9,10 +9,10 @@ test('it renders', function(assert) {
   assert.expect(2);
   let date = new Date('2015-09-30T12:00:00');
   this.set('date', date);
-
-  this.render(hbs`{{ilios-calendar-day date=date}}`);
+  this.set('nothing', parseInt);
+  this.render(hbs`{{ilios-calendar-day date=date selectEvent=(action nothing)}}`);
   //Date input is Wednesday, Septrmber 30th.  Should be the first string
   assert.equal(this.$().text().trim().search(/^Wednesday/), 0);
   assert.equal(this.$('.event').length, 0);
-  
+
 });

--- a/tests/integration/components/ilios-calendar-month-test.js
+++ b/tests/integration/components/ilios-calendar-month-test.js
@@ -28,10 +28,15 @@ test('month displays with three events', function(assert) {
   thirdEvent.endDate = date.clone().add(4, 'hour');
 
   this.set('events', [firstEvent, secondEvent, thirdEvent]);
+  this.set('nothing', parseInt);
   const events = '.event';
   const more = '.month-more-events';
 
-  this.render(hbs`{{ilios-calendar-month date=date calendarEvents=events showMore='Show More'}}`);
+  this.render(hbs`{{ilios-calendar-month
+    date=date
+    calendarEvents=events
+    selectEvent=(action nothing)
+    showMore='Show More'}}`);
   //Date input is Wednesday, Septrmber 30th.  Should be the first string
   assert.equal(this.$().text().trim().search(/^September 2015/), 0);
   assert.equal(this.$(events).length, 2);
@@ -44,6 +49,7 @@ test('month displays with two events', function(assert) {
   let date = moment(new Date('2015-09-30T12:00:00'));
 
   this.set('date', date.toDate());
+  this.set('nothing', parseInt);
 
   let firstEvent = createUserEventObject();
   firstEvent.name = 'Some new thing';
@@ -59,7 +65,11 @@ test('month displays with two events', function(assert) {
   const events = '.event';
   const more = '.month-more-events';
 
-  this.render(hbs`{{ilios-calendar-month date=date calendarEvents=events showMore='Show More'}}`);
+  this.render(hbs`{{ilios-calendar-month
+    date=date
+    calendarEvents=events
+    selectEvent=(action nothing)
+    showMore='Show More'}}`);
   //Date input is Wednesday, Septrmber 30th.  Should be the first string
   assert.equal(this.$().text().trim().search(/^September 2015/), 0);
   assert.equal(this.$(events).length, 2);
@@ -71,12 +81,6 @@ test('clicking on a day fires the correct event', function(assert) {
   let date = new Date('2015-09-30T12:00:00');
   this.set('date', date);
 
-  this.render(hbs`{{ilios-calendar-month
-    date=date
-    changeDate='changeDate'
-    changeView='changeView'
-    calendarEvents=events
-  }}`);
   this.on('changeDate', newDate => {
     assert.ok(newDate instanceof Date);
     assert.ok(newDate.toString().search(/Sun Aug 30/) === 0);
@@ -84,6 +88,14 @@ test('clicking on a day fires the correct event', function(assert) {
   this.on('changeView', newView => {
     assert.equal(newView, 'day');
   });
+
+  this.render(hbs`{{ilios-calendar-month
+    date=date
+    changeDate=(action 'changeDate')
+    changeView=(action 'changeView')
+    calendarEvents=events
+  }}`);
+
   this.$('.day .clickable').eq(0).click();
 });
 

--- a/tests/integration/components/ilios-calendar-multiday-event-test.js
+++ b/tests/integration/components/ilios-calendar-multiday-event-test.js
@@ -16,48 +16,47 @@ moduleForComponent('ilios-calendar-multiday-event', 'Integration | Component | i
 });
 
 test('event displays correctly', function(assert) {
+  assert.expect(4);
   let event = getEvent();
   this.set('event', event);
-  assert.expect(4);
+  this.set('nothing', parseInt);
+  this.render(hbs`{{ilios-calendar-multiday-event event=event selectEvent=(action nothing)}}`);
 
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
-  this.render(hbs`{{ilios-calendar-multiday-event event=event}}`);
-  
   assert.equal(this.$().text().search(/11\/11\/84/), 0);
   assert.equal(this.$().text().search(/11\/12\/84/), 19);
-  assert.equal(this.$().text().search(/Cheramie is born/), 40);
-  assert.equal(this.$().text().search(/Lancaster, CA/), 60);
-  
+  assert.equal(this.$().text().search(/Cheramie is born/), 39);
+  assert.equal(this.$().text().search(/Lancaster, CA/), 57);
+
 });
 
 test('action fires on click', function(assert) {
   let event = getEvent();
   event.offering = 1;
-  
+
   this.set('event', event);
   assert.expect(2);
-  this.render(hbs`{{ilios-calendar-multiday-event event=event action='handleAction'}}`);
-  assert.ok(this.$().text().search(/Cheramie is born/) > 0);
   this.on('handleAction', (value) => {
     assert.deepEqual(event, value);
   });
-  
+  this.render(hbs`{{ilios-calendar-multiday-event event=event selectEvent=(action 'handleAction' event)}}`);
+  assert.ok(this.$().text().search(/Cheramie is born/) > 0);
+
+
   this.$('.clickable').click();
 });
 
 test('action does not fire for scheduled events', function(assert) {
   let event = getEvent();
-  
+
   this.set('event', event);
   assert.expect(1);
-  this.render(hbs`{{ilios-calendar-multiday-event event=event action='handleAction'}}`);
-  assert.ok(this.$().text().search(/Cheramie is born/) > 0);
   this.on('handleAction', () => {
     //this should never get called
     assert.ok(false);
   });
-  
+  this.render(hbs`{{ilios-calendar-multiday-event event=event selectEvent=(action 'handleAction')}}`);
+  assert.ok(this.$().text().search(/Cheramie is born/) > 0);
+
+
   this.$('.clickable').click();
 });

--- a/tests/integration/components/ilios-calendar-test.js
+++ b/tests/integration/components/ilios-calendar-test.js
@@ -14,8 +14,16 @@ test('it renders', function(assert) {
   this.set('events', events);
   let date = new Date('2015-09-30T12:00:00');
   this.set('date', date);
+  this.set('nothing', parseInt)
 
-  this.render(hbs`{{ilios-calendar selectedDate=date selectedView='day' calendarEventsPromise=events}}`);
+  this.render(hbs`{{ilios-calendar
+    selectedDate=date
+    selectedView='day'
+    calendarEventsPromise=events
+    changeDate=(action nothing)
+    changeView=(action nothing)
+    selectEvent=(action nothing)
+  }}`);
 
   assert.ok(this.$().text().trim().search(/Wednesday, September 30th 2015/) !== -1);
 });

--- a/tests/integration/components/ilios-calendar-week-test.js
+++ b/tests/integration/components/ilios-calendar-week-test.js
@@ -19,12 +19,6 @@ test('clicking on a day header fires the correct events', function(assert) {
   assert.expect(3);
   let date = new Date('2015-09-30T12:00:00');
   this.set('date', date);
-
-  this.render(hbs`{{ilios-calendar-week
-    date=date
-    changeDate='changeDate'
-    changeView='changeView'
-  }}`);
   this.on('changeDate', newDate => {
     assert.ok(newDate instanceof Date);
     assert.ok(newDate.toString().search(/Sun Sep 27/) === 0);
@@ -32,6 +26,13 @@ test('clicking on a day header fires the correct events', function(assert) {
   this.on('changeView', newView => {
     assert.equal(newView, 'day');
   });
+
+  this.render(hbs`{{ilios-calendar-week
+    date=date
+    changeDate=(action 'changeDate')
+    changeView=(action 'changeView')
+  }}`);
+
 
   this.$('.week-titles .clickable').eq(0).click();
 });


### PR DESCRIPTION
Removes a lot of boilerplate and makes it easier to trace the results of
user actions up to their change point.

Fixes #106