### PR TITLE
Lock our version of node-sass to v4.3.0

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,11 +1,15 @@
 /*eslint-env node*/
 /* global require, module */
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+var nodeSass = require('node-sass'); // loads the version in your package.json
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     emberCliFontAwesome: {
       useScss: true
+    },
+    sassOptions: {
+      nodeSass: nodeSass
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   name: 'ilios-calendar',
   //needed for scss to get pushed up to parent app
-  included: function(app) {
-    this._super.included(app);
+  included: function(/* app */) {
+    this._super.included.apply(this, arguments);
   }
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.0",
-    "ember-cli-sass": "^6.1.0"
+    "ember-cli-sass": "^6.1.0",
+    "node-sass": "4.3.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.6",


### PR DESCRIPTION
The newest version relies on a beta version of libsass which breaks for
us.  Instead we pin our version and wait for a fix.