### PR TITLE
Hardwired "Taught by" and "Course" Labels in Month View

### DIFF
--- a/addon/components/ilios-calendar-event-month.js
+++ b/addon/components/ilios-calendar-event-month.js
@@ -12,7 +12,11 @@ export default CalendarEvent.extend(TooltipContent, {
   layout,
   event: null,
   timeFormat: 'h:mma',
+  taughtByPhrase: 'Taught by',
+  courseTitlePhrase: 'Course',
   multiplePhrase: 'Multiple',
+  etAlPhrase: 'et al.',
+  ilmDuePhrase: 'ILM - Due',
   classNameBindings: [':event', ':event-pos', ':ilios-calendar-event', 'event.eventClass', ':month-event', 'clickable:clickable'],
   style: computed(function() {
     return new SafeString('');


### PR DESCRIPTION
Temporary fix. 

Refs ilios/frontend#2504 

