### PR TITLE
Updated to the latest ember-font-awesome

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,5 +1,3 @@
-@import 'bower_components/font-awesome/scss/font-awesome';
-
 $white: #fff;
 $black: #000;
 $grey: #eee;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,0 +1,1 @@
+@import 'font-awesome';

--- a/blueprints/ilios-calendar/index.js
+++ b/blueprints/ilios-calendar/index.js
@@ -1,0 +1,17 @@
+/*eslint-env node*/
+/* global require, module */
+
+module.exports = {
+  description: 'Add a project dep for ember-font-awesome',
+
+  normalizeEntityName: function() {
+    // allows us to run ember -g ilios-frontend and not blow up
+    // because ember cli normally expects the format
+    // ember generate <entitiyName> <blueprint>
+  },
+
+  afterInstall: function() {
+    return this.addAddonToProject('ember-font-awesome');
+  },
+
+};

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "ilios-calendar",
   "dependencies": {
-    "font-awesome": "~4.5.0",
     "clipboard": "~1.5.5",
     "ember": "~2.10.0",
     "ember-cli-shims": "0.1.3"

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,8 +5,8 @@ var nodeSass = require('node-sass'); // loads the version in your package.json
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    emberCliFontAwesome: {
-      useScss: true
+    'ember-font-awesome': {
+      useScss: true,
     },
     sassOptions: {
       nodeSass: nodeSass

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
-    "ember-font-awesome": "2.2.0",
+    "ember-font-awesome": "3.0.3",
     "ember-load-initializers": "^0.6.1",
     "ember-moment": "7.3.0",
     "ember-resolver": "^2.0.3",


### PR DESCRIPTION
This no longer requires the bower.json package. Also stopped attempting
to send font-awesome upstream in our scss file.  That becomes the
responsibility of the addon consumer.