### PR TITLE
Address infinite re-rendering issues

### DIFF
--- a/addon/components/ilios-calendar-event.js
+++ b/addon/components/ilios-calendar-event.js
@@ -32,7 +32,7 @@ export default CalendarEvent.extend(TooltipContent, {
   isOffering: notEmpty('event.offering'),
   clickable: or('isIlm', 'isOffering'),
 
-  formattedInstructors: computed(function() {
+  formattedInstructors: computed('event.instructors.[]', function() {
     let instructors = this.get('event.instructors');
     if (! isArray(instructors) || ! instructors.length) {
       return '';
@@ -44,7 +44,7 @@ export default CalendarEvent.extend(TooltipContent, {
     }
   }),
 
-  style: computed(function() {
+  style: computed('event', function() {
     const event = this.get('event');
     if (event == null) {
       return new SafeString('');

--- a/addon/templates/components/ilios-calendar-event.hbs
+++ b/addon/templates/components/ilios-calendar-event.hbs
@@ -8,14 +8,12 @@
     {{/if}}
 
     {{#unless isMonth}}
-      {{#unless event.isPublished}}
+      {{#if (not event.isPublished)}}
         {{fa-icon 'files-o'}}
-      {{/unless}}
-      {{#if (and event.isScheduled event.isPublished)}}
+      {{else if event.isScheduled}}
         {{fa-icon 'clock-o'}}
       {{/if}}
     {{/unless}}
-
     <span class='ilios-calendar-event-time'>
       {{#if isIlm}}
         <span class='ilios-calendar-event-start'>


### PR DESCRIPTION
Not passing keys to computed properties and having a weird unless / if
syntax was getting our events flagged as infinitely re-rendering event
thought they probably weren't infinite, they certainly were not optimal.